### PR TITLE
Fix memory leak in font dynamic textures

### DIFF
--- a/Source/MV/Render/formattedText.cpp
+++ b/Source/MV/Render/formattedText.cpp
@@ -60,16 +60,15 @@ namespace MV {
 	/*************************\
 	| --CharacterDefinition-- |
 	\*************************/
-
 	std::shared_ptr<CharacterDefinition> CharacterDefinition::make(std::shared_ptr<SurfaceTextureDefinition> a_texture, const std::string &a_glyphCharacter, std::shared_ptr<FontDefinition> a_fontDefinition) {
-		return std::shared_ptr<CharacterDefinition>(new CharacterDefinition(a_texture, a_glyphCharacter, a_fontDefinition));
+	return std::shared_ptr<CharacterDefinition>(new CharacterDefinition(a_texture, a_glyphCharacter, a_fontDefinition));
 	}
 	
 	CharacterDefinition::CharacterDefinition(std::shared_ptr<SurfaceTextureDefinition> a_texture, const std::string &a_glyphCharacter, std::shared_ptr<FontDefinition> a_fontDefinition):
-		glyphTexture(a_texture),
-		glyphHandle(a_texture->makeHandle()),
-		glyphCharacter(a_glyphCharacter),
-		fontDefinition(a_fontDefinition){
+	glyphTexture(a_texture),
+	glyphHandle(a_texture->makeHandle()),
+	glyphCharacter(a_glyphCharacter),
+	fontDefinition(a_fontDefinition){
 
 		glyphHandle->bounds(glyphTexture->surfaceSize());
 	}
@@ -95,7 +94,7 @@ namespace MV {
 	}
 
 	std::shared_ptr<FontDefinition> CharacterDefinition::font() const {
-		return fontDefinition;
+		return fontDefinition.lock();
 	}
 
 

--- a/Source/MV/Render/formattedText.cpp
+++ b/Source/MV/Render/formattedText.cpp
@@ -61,14 +61,14 @@ namespace MV {
 	| --CharacterDefinition-- |
 	\*************************/
 	std::shared_ptr<CharacterDefinition> CharacterDefinition::make(std::shared_ptr<SurfaceTextureDefinition> a_texture, const std::string &a_glyphCharacter, std::shared_ptr<FontDefinition> a_fontDefinition) {
-	return std::shared_ptr<CharacterDefinition>(new CharacterDefinition(a_texture, a_glyphCharacter, a_fontDefinition));
+		return std::shared_ptr<CharacterDefinition>(new CharacterDefinition(a_texture, a_glyphCharacter, a_fontDefinition));
 	}
 	
 	CharacterDefinition::CharacterDefinition(std::shared_ptr<SurfaceTextureDefinition> a_texture, const std::string &a_glyphCharacter, std::shared_ptr<FontDefinition> a_fontDefinition):
-	glyphTexture(a_texture),
-	glyphHandle(a_texture->makeHandle()),
-	glyphCharacter(a_glyphCharacter),
-	fontDefinition(a_fontDefinition){
+		glyphTexture(a_texture),
+		glyphHandle(a_texture->makeHandle()),
+		glyphCharacter(a_glyphCharacter),
+		fontDefinition(a_fontDefinition){
 
 		glyphHandle->bounds(glyphTexture->surfaceSize());
 	}

--- a/Source/MV/Render/formattedText.h
+++ b/Source/MV/Render/formattedText.h
@@ -170,7 +170,7 @@ namespace MV {
 		std::string glyphCharacter;
 		std::shared_ptr<SurfaceTextureDefinition> glyphTexture;
 		std::shared_ptr<TextureHandle> glyphHandle;
-		std::shared_ptr<FontDefinition> fontDefinition;
+		std::weak_ptr<FontDefinition> fontDefinition;
 	};
 
 	///////////////////////////////////

--- a/Source/MV/Render/textures.cpp
+++ b/Source/MV/Render/textures.cpp
@@ -346,9 +346,9 @@ namespace MV {
 		if (RUNNING_IN_HEADLESS) { return; }
 		loadedTexture = std::make_unique<LoadedTexture>(TextureParameters());
 		loadedTexture->data().originalSize.width = desiredSize.width;
-		loadedTexture->data().originalSize.width = desiredSize.height;
+		loadedTexture->data().originalSize.height = desiredSize.height;
 		loadedTexture->data().size.width = textureSize.width;
-		loadedTexture->data().size.width = textureSize.height;
+		loadedTexture->data().size.height = textureSize.height;
 
 		// Create Storage Space For Texture Data (128x128x4)
 		std::vector<unsigned char> pixels(static_cast<size_t>(textureSize.width) * textureSize.height * 4);


### PR DESCRIPTION
## Summary
- break cyclical strong references between fonts and character definitions
- correct saved texture size data in DynamicTextureDefinition
- fix indentation after feedback

## Testing
- `git status --short`