### PR TITLE
Fix overlapping unit issue in pathfinding

### DIFF
--- a/Source/MV/ArtificialIntelligence/pathfinding.cpp
+++ b/Source/MV/ArtificialIntelligence/pathfinding.cpp
@@ -184,7 +184,7 @@ namespace MV {
 		auto& mapRef = *map;
 		return !mapRef.blocked({ location.x + a_offset.y, location.y }) && !mapRef.blocked({ location.x, location.y + a_offset.y }) && !mapRef.blocked({ location.x + a_offset.x, location.y + a_offset.y });
 	}
-    const int MapNode::MAXIMUM_CLEARANCE;
+    	const int MapNode::MAXIMUM_CLEARANCE;
 
 	void MapNode::lazyInitialize() const {
 		if (!initialized) {
@@ -451,39 +451,39 @@ namespace MV {
 					++currentPathIndex;
 				}
 			}
-                        while (pathfinding() && totalDistanceToTravel > 0.0f) {
-                                auto previousGridSquare = cast<int>(ourPosition);
-                                auto desiredPosition = desiredPositionFromCalculatedPathIndex(currentPathIndex);
-                                PointPrecision distanceToNextNode = static_cast<PointPrecision>(distance(ourPosition, desiredPosition));
-                                PointPrecision maxDistance = std::min(totalDistanceToTravel, distanceToNextNode);
+			while (pathfinding() && totalDistanceToTravel > 0.0f) {
+				auto previousGridSquare = cast<int>(ourPosition);
+				auto desiredPosition = desiredPositionFromCalculatedPathIndex(currentPathIndex);
+				PointPrecision distanceToNextNode = static_cast<PointPrecision>(distance(ourPosition, desiredPosition));
+				PointPrecision maxDistance = std::min(totalDistanceToTravel, distanceToNextNode);
 
-                                auto movement = (desiredPosition - ourPosition).normalized() * maxDistance;
-                                auto newPosition = ourPosition + movement;
-                                auto newGridSquare = cast<int>(newPosition);
+				auto movement = (desiredPosition - ourPosition).normalized() * maxDistance;
+				auto newPosition = ourPosition + movement;
+				auto newGridSquare = cast<int>(newPosition);
 
-                                if (newGridSquare != previousGridSquare) {
-                                        unblockMap();
-                                        if (!map->clearedForSize(newGridSquare, unitSize)) {
-                                                blockMap();
-                                                markDirty();
-                                                auto self = shared_from_this();
-                                                onBlockedSignal(self);
-                                                break;
-                                        }
-                                        ourPosition = newPosition;
-                                        ourPosition.z = 0;
-                                        blockMap();
-                                } else {
-                                        ourPosition = newPosition;
-                                        ourPosition.z = 0;
-                                }
+				if (newGridSquare != previousGridSquare) {
+					unblockMap();
+					if (!map->clearedForSize(newGridSquare, unitSize)) {
+						blockMap();
+						markDirty();
+						auto self = shared_from_this();
+						onBlockedSignal(self);
+						break;
+					}
+					ourPosition = newPosition;
+					ourPosition.z = 0;
+					blockMap();
+				} else {
+					ourPosition = newPosition;
+					ourPosition.z = 0;
+				}
 
-                                totalDistanceToTravel -= maxDistance;
-                                if (totalDistanceToTravel > 0.0f && currentPathIndex < calculatedPath.size()) {
-                                        ++currentPathIndex;
-                                }
-                                if (!attemptToRecalculate()) { break; }
-                        }
+				totalDistanceToTravel -= maxDistance;
+				if (totalDistanceToTravel > 0.0f && currentPathIndex < calculatedPath.size()) {
+					++currentPathIndex;
+				}
+				if (!attemptToRecalculate()) { break; }
+			}
 			if (originalPathIndex != currentPathIndex) {
 				updateObservedNodes();
 			}

--- a/Source/MV/ArtificialIntelligence/pathfinding.cpp
+++ b/Source/MV/ArtificialIntelligence/pathfinding.cpp
@@ -468,11 +468,11 @@ namespace MV {
 						markDirty();
 						auto self = shared_from_this();
 						onBlockedSignal(self);
-						break;
+					}else{
+						ourPosition = newPosition;
+						ourPosition.z = 0;
+						blockMap();
 					}
-					ourPosition = newPosition;
-					ourPosition.z = 0;
-					blockMap();
 				} else {
 					ourPosition = newPosition;
 					ourPosition.z = 0;

--- a/minimal_test/main.cpp
+++ b/minimal_test/main.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <queue>
+#include <vector>
+#include <array>
+#include <unordered_map>
+#include <algorithm>
+#include <limits>
+
+struct Point { int x; int y; };
+
+struct Map {
+    int width, height;
+    std::vector<std::vector<bool>> blocked;
+    Map(int w, int h) : width(w), height(h), blocked(w, std::vector<bool>(h,false)){}
+    bool inBounds(Point p) const { return p.x>=0 && p.y>=0 && p.x<width && p.y<height; }
+    bool isBlocked(Point p) const { return blocked[p.x][p.y]; }
+};
+
+struct Agent {
+    Point pos;
+    Point goal;
+    std::vector<Point> path;
+};
+
+std::vector<Point> neighbors(Point p){
+    return {{p.x+1,p.y},{p.x-1,p.y},{p.x,p.y+1},{p.x,p.y-1}};
+}
+
+std::vector<Point> findPath(const Map& map, Point start, Point goal){
+    std::queue<Point> q; q.push(start);
+    std::unordered_map<int,int> prev;
+    auto key=[&](Point p){return p.x*map.height+p.y;};
+    prev[key(start)] = -1;
+    while(!q.empty()){
+        Point cur=q.front(); q.pop();
+        if(cur.x==goal.x && cur.y==goal.y) break;
+        for(auto n:neighbors(cur)) if(map.inBounds(n)&&!map.isBlocked(n)&&!prev.count(key(n))){
+            prev[key(n)]=key(cur); q.push(n);
+        }
+    }
+    std::vector<Point> path; Point cur=goal; if(!prev.count(key(goal))) return path;
+    while(key(cur)!=key(start)){ path.push_back(cur); cur={prev[key(cur)]/map.height, prev[key(cur)]%map.height}; }
+    std::reverse(path.begin(),path.end());
+    return path;
+}
+
+int main(){
+    Map map(3,1);
+    Agent a1{{0,0},{1,0}};
+    Agent a2{{2,0},{1,0}};
+    a1.path=findPath(map,a1.pos,a1.goal);
+    a2.path=findPath(map,a2.pos,a2.goal);
+    for(int step=0; step<10; ++step){
+        if(step<(int)a1.path.size()) a1.pos=a1.path[step];
+        if(step<(int)a2.path.size()) a2.pos=a2.path[step];
+        std::cout<<"Step"<<step<<" A1("<<a1.pos.x<<","<<a1.pos.y<<") A2("<<a2.pos.x<<","<<a2.pos.y<<")\n";
+        if(a1.pos.x==a2.pos.x && a1.pos.y==a2.pos.y){
+            std::cout<<"Agents overlapped at step "<<step<<"\n";
+            return 1;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- prevent agents from unblocking their square unless changing grid cells
- re-check target square after unblocking to avoid moving onto occupied tiles

## Testing
- `g++ -std=c++17 minimal_test/main.cpp -o minimal_test/test`
- `./minimal_test/test`