### PR TITLE
Add basic property system

### DIFF
--- a/Source/MV/Render/Scene/drawable.h
+++ b/Source/MV/Render/Scene/drawable.h
@@ -2,6 +2,7 @@
 #define _MV_SCENE_DRAWABLE_H_
 
 #include "node.h"
+#include "MV/Utility/properties.h"
 
 #define DrawableDerivedAccessorsShowHide(ComponentType) \
 	std::shared_ptr<ComponentType> show() { \
@@ -133,7 +134,7 @@ namespace MV {
 			void registerWithParent();
 		};
 
-		class Drawable : public Component {
+               class Drawable : public Component, public MV::PropertyHost {
 			friend Anchors;
 			friend Node;
 			friend cereal::access;
@@ -383,7 +384,7 @@ namespace MV {
 
 			GLenum drawType = GL_TRIANGLES;
 
-			bool shouldDraw = true;
+                       MV::MvProperty<bool> shouldDraw{Properties, "shouldDraw", true};
 
 			virtual void initialize() override;
 
@@ -395,7 +396,7 @@ namespace MV {
 			void hookupTextureSizeWatchers();
 			void hookupTextureSizeWatcher(size_t a_textureId);
 
-			BlendModePreset blendModePreset = DEFAULT;
+                       MV::MvProperty<BlendModePreset> blendModePreset{Properties, "blendMode", DEFAULT};
 
 			void rebuildTextureCache();
 

--- a/Source/MV/Utility/CMakeLists.txt
+++ b/Source/MV/Utility/CMakeLists.txt
@@ -21,4 +21,5 @@ target_sources(BindStone PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/tupleHelpers.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/task.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/taskActions.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/properties.h
 )

--- a/Source/MV/Utility/properties.h
+++ b/Source/MV/Utility/properties.h
@@ -1,0 +1,70 @@
+#ifndef _MV_PROPERTIES_H_
+#define _MV_PROPERTIES_H_
+
+#include <string>
+#include <vector>
+#include "cereal/cereal.hpp"
+
+namespace MV {
+
+    class MvPropertyBase;
+
+    class MvPropertyList {
+    public:
+        void add(MvPropertyBase* a_property) {
+            properties.push_back(a_property);
+        }
+
+        const std::vector<MvPropertyBase*>& all() const { return properties; }
+    private:
+        std::vector<MvPropertyBase*> properties;
+    };
+
+    class PropertyHost {
+    public:
+        MvPropertyList Properties;
+    };
+
+    class MvPropertyBase {
+    public:
+        MvPropertyBase() = default;
+        MvPropertyBase(MvPropertyList& a_list, const std::string& a_name) {
+            registerWith(a_list, a_name);
+        }
+        virtual ~MvPropertyBase() = default;
+
+        const std::string& name() const { return propertyName; }
+    protected:
+        void registerWith(MvPropertyList& a_list, const std::string& a_name) {
+            propertyName = a_name;
+            a_list.add(this);
+        }
+    private:
+        std::string propertyName;
+    };
+
+    template<typename T>
+    class MvProperty : public MvPropertyBase {
+    public:
+        using value_type = T;
+        MvProperty() = default;
+        MvProperty(MvPropertyList& a_list, const std::string& a_name, const T& a_default = T{})
+            : MvPropertyBase(a_list, a_name), value(a_default) {}
+
+        MvProperty& operator=(const T& a_val) { value = a_val; return *this; }
+        operator const T&() const { return value; }
+        const T& get() const { return value; }
+        T& get() { return value; }
+
+        template<class Archive>
+        T save_minimal(const Archive&) const { return value; }
+
+        template<class Archive>
+        void load_minimal(const Archive&, const T& a_val) { value = a_val; }
+    private:
+        T value{};
+    };
+
+}
+
+#endif


### PR DESCRIPTION
## Summary
- introduce property containers and property wrappers in `properties.h`
- expose new header via Utility `CMakeLists.txt`
- test the system on `Drawable` by converting `shouldDraw` and `blendModePreset` to `MvProperty`

## Testing
- `g++ minimal_test/main.cpp -std=c++17 -O2 -o minimal_test/main`