### PR TITLE
Fix handleExpiredPlayers queue re-addition

### DIFF
--- a/Source/Game/NetworkLayer/lobbyServer.cpp
+++ b/Source/Game/NetworkLayer/lobbyServer.cpp
@@ -68,10 +68,10 @@ bool LobbyGameConnectionState::handleExpiredPlayers() {
 			leftPlayer->queue.add(leftPlayer);
 			leftPlayer.reset();
 		}
-		if (!rightPlayer->lifespan.expired()) {
-			rightPlayer->queue.add(leftPlayer);
-			rightPlayer.reset();
-		}
+                if (!rightPlayer->lifespan.expired()) {
+                        rightPlayer->queue.add(rightPlayer);
+                        rightPlayer.reset();
+                }
 		return true;
 	}
 	return false;


### PR DESCRIPTION
## Summary
- return the right player to their queue in `handleExpiredPlayers`

## Testing
- `g++ minimal_test/main.cpp -o minimal_test/main && ./minimal_test/main` *(fails: Agents overlapped)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.