### PR TITLE
Use base Creature pointers in registry

### DIFF
--- a/Source/Game/Instance/gameInstance.h
+++ b/Source/Game/Instance/gameInstance.h
@@ -98,17 +98,17 @@ public:
 	virtual void spawnCreature(int /*a_buildingSlot*/, const std::string &/*a_creatureId*/) {
 	}
 
-	void registerCreature(std::shared_ptr<ServerCreature> &a_registerCreature) {
-		if (a_registerCreature->alive()) {
-			creatures[a_registerCreature->netId()] = a_registerCreature;
-			a_registerCreature->onDeath.connect("_RemoveFromTeam", [&](std::shared_ptr<Creature> a_creature) {
-				creatures.erase(a_creature->netId());
-			});
-		}
-	}
+        void registerCreature(std::shared_ptr<Creature> a_registerCreature) {
+                if (a_registerCreature->alive()) {
+                        creatures[a_registerCreature->netId()] = a_registerCreature;
+                        a_registerCreature->onDeath.connect("_RemoveFromTeam", [&](std::shared_ptr<Creature> a_creature) {
+                                creatures.erase(a_creature->netId());
+                        });
+                }
+        }
 
-	const std::shared_ptr<ServerCreature> &creature(int64_t a_id) {
-		static std::shared_ptr<ServerCreature> nullCreature;
+        const std::shared_ptr<Creature> &creature(int64_t a_id) {
+                static std::shared_ptr<Creature> nullCreature;
 		if (a_id == 0) {
 			return nullCreature;
 		}
@@ -137,8 +137,8 @@ protected:
 	void rawScaleAroundScreenPoint(float a_amount, const MV::Point<int>& a_position);
 	void easeToBoundsIfExceeded(const MV::Point<int>& a_pointerCenter);
 
-	std::vector<std::shared_ptr<Building>> buildings;
-	std::map<int64_t, std::shared_ptr<ServerCreature>> creatures;
+        std::vector<std::shared_ptr<Building>> buildings;
+        std::map<int64_t, std::shared_ptr<Creature>> creatures;
 
 	GameData& gameData;
 

--- a/Source/Game/Instance/team.cpp
+++ b/Source/Game/Instance/team.cpp
@@ -19,19 +19,19 @@ void Team::initialize() {
 }
 
 std::vector<std::shared_ptr<ServerCreature>> Team::creaturesInRange(const MV::Point<> &a_location, float a_radius) {
-	std::vector<std::shared_ptr<ServerCreature>> result;
-	std::unordered_map<ServerCreature*, double> distances;
-	for (auto&& kv : game.creatures) {
-		auto a_creature = kv.second;
-		if ((game.teamForPlayer(a_creature->player()).side() == ourSide) && a_creature->alive()){
-			auto ourDistance = MV::distance(a_location, a_creature->agent()->gridPosition());
-			distances[kv.second.get()] = ourDistance;
-			if (ourDistance <= a_radius) {
-				MV::insertSorted(result, a_creature, [&](const std::shared_ptr<ServerCreature> &a_lhs, const std::shared_ptr<ServerCreature> &a_rhs) {
-					return distances[a_lhs.get()] < distances[a_rhs.get()];
-				});
-			}
-		}
-	}
-	return result;
+        std::vector<std::shared_ptr<ServerCreature>> result;
+        std::unordered_map<ServerCreature*, double> distances;
+        for (auto&& kv : game.creatures) {
+                auto a_creature = std::dynamic_pointer_cast<ServerCreature>(kv.second);
+                if (a_creature && (game.teamForPlayer(a_creature->player()).side() == ourSide) && a_creature->alive()) {
+                        auto ourDistance = MV::distance(a_location, a_creature->agent()->gridPosition());
+                        distances[a_creature.get()] = ourDistance;
+                        if (ourDistance <= a_radius) {
+                                MV::insertSorted(result, a_creature, [&](const std::shared_ptr<ServerCreature> &a_lhs, const std::shared_ptr<ServerCreature> &a_rhs) {
+                                        return distances[a_lhs.get()] < distances[a_rhs.get()];
+                                });
+                        }
+                }
+        }
+        return result;
 }

--- a/Source/Game/creature.cpp
+++ b/Source/Game/creature.cpp
@@ -62,10 +62,10 @@ void ServerCreature::initialize() {
 		onBlockedSignal(std::static_pointer_cast<ServerCreature>(shared_from_this()));
 	});
 	
-	auto self = std::static_pointer_cast<ServerCreature>(shared_from_this());
-	statTemplate.script(gameInstance.script()).spawn(self);
+        auto self = std::static_pointer_cast<ServerCreature>(shared_from_this());
+        statTemplate.script(gameInstance.script()).spawn(self);
 
-	gameInstance.registerCreature(self);
+        gameInstance.registerCreature(self);
 }
 
 void ServerCreature::updateImplementation(double a_delta) {
@@ -105,9 +105,9 @@ void TargetPolicy::target(int64_t a_targetId, float a_range, std::function<void(
 	if (!selfCreature->alive()) {
 		a_fail(*this);
 	}
-	auto a_target = self()->gameInstance.creature(a_targetId);
-
-	if (a_target.get() == targetCreature) { return; }
+        auto a_target = std::dynamic_pointer_cast<ServerCreature>(self()->gameInstance.creature(a_targetId));
+        
+        if (a_target.get() == targetCreature) { return; }
 
 	clearTarget();
 	if (!stunDuration && selfCreature) {
@@ -274,7 +274,7 @@ void ClientCreature::initialize() {
 	newNode->serializable(false);
 	spineAnimator = newNode->componentInChildren<MV::Scene::Spine>().get();
 
-	auto self = std::static_pointer_cast<ServerCreature>(shared_from_this());
+	auto self = std::static_pointer_cast<ClientCreature>(shared_from_this());
 	statTemplate.script(gameInstance.script()).spawn(self);
 
 	gameInstance.registerCreature(self);

--- a/Source/Game/creature.h
+++ b/Source/Game/creature.h
@@ -351,8 +351,8 @@ public:
 
 			if (health != newHealth) {
 				state->modify()->health = newHealth;
-				auto self = std::static_pointer_cast<ServerCreature>(shared_from_this());
-				onHealthChangeSignal(self, amount);
+                                auto self = std::static_pointer_cast<ClientCreature>(shared_from_this());
+                                onHealthChangeSignal(self, amount);
 			}
 
 			if (newHealth <= 0) {
@@ -464,9 +464,9 @@ protected:
 	}
 
 private:
-	void animateDeathAndRemove() {
-		auto self = std::static_pointer_cast<ServerCreature>(shared_from_this());
-		onDeathSignal(self);
+        void animateDeathAndRemove() {
+                auto self = std::static_pointer_cast<ClientCreature>(shared_from_this());
+                onDeathSignal(self);
 		task().cancel();
 		if (owner()->position() != *state->self()->position) {
 			task().now("Tween", [&](MV::Task&, double a_dt) {


### PR DESCRIPTION
## Summary
- store `std::shared_ptr<Creature>` in `GameInstance` registry
- adapt `registerCreature` and `creature()` helpers
- update team creature lookup
- fix `ClientCreature` casts
- cast when looking up targets

## Testing
- `make -C minimal_test` *(fails: "No targets specified and no makefile found")*