### PR TITLE
Add AGENTS documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repository Overview
+
+This repo contains the game **Bindstone** built with the **MutedVision (MV)** engine.  The MV engine was written by Devacor (Michael Hamilton).  Third party libraries reside under the `External` folder and include packages such as Box2D, ChaiScript, boolinq (LINQ), cereal, gl3w, glm and SDL2.
+
+## Projects
+- Windows client and Android client (see `Source/SolutionSpecific/BindstoneClient` and `BindstoneClient_Android`).
+- Game server (`Source/SolutionSpecific/BindstoneGameServer`).
+- Lobby server (`Source/SolutionSpecific/BindstoneLobbyServer`).
+
+The `VSProjects` folder contains Visual Studio project files.  Source code lives under `Source` and game assets under `Assets`.
+
+Each major subdirectory has its own `AGENTS.md` with more specific notes.

--- a/Assets/AGENTS.md
+++ b/Assets/AGENTS.md
@@ -1,0 +1,15 @@
+# Game Assets
+
+Contains JSON catalogs, scripts and art used by the game.
+
+Key subfolders:
+- `Animations.json` and sprite atlases under `Atlases/`.
+- `Audio/` – ogg sound files.
+- `BattleEffects/` – effect prefabs and scripts.
+- `Buildings/` – building prefabs and scripts.
+- `Catalogs/` – JSON data describing buildings, creatures and effects.
+- `Creatures/` – creature prefabs, Spine data and scripts.
+- `Fonts/`, `Images/` – miscellaneous art assets.
+- `Interface/` – GUI scenes and scripts (login, main menu, shared widgets).
+
+Scripts use ChaiScript syntax and are loaded via the MV script engine.

--- a/Assets/BattleEffects/AGENTS.md
+++ b/Assets/BattleEffects/AGENTS.md
@@ -1,0 +1,7 @@
+# Battle Effect Assets
+
+Scripts and prefabs for effects used during combat.
+- `main.script` and `mainClient.script` define server/client behaviour.
+- Subfolders like `Missile/Default` hold effect prefabs.
+
+Effect types are listed in `Assets/Catalogs/BattleEffects.json`.

--- a/Assets/Buildings/AGENTS.md
+++ b/Assets/Buildings/AGENTS.md
@@ -1,0 +1,7 @@
+# Building Assets
+
+Each building folder mirrors the structure used for creatures.
+- `Default/` contains prefab definitions (`building.prefab`).
+- `main.script` and `mainClient.script` define server/client behaviour.
+
+Data is referenced from `Assets/Catalogs/Buildings.json`.

--- a/Assets/Creatures/AGENTS.md
+++ b/Assets/Creatures/AGENTS.md
@@ -1,0 +1,7 @@
+# Creature Assets
+
+Each subfolder represents a creature.  Inside you will typically find:
+- `Default/` – prefab data (`unit.prefab` plus images or Spine data).
+- `main.script` and `mainClient.script` – server and client logic for the creature.
+
+Creature stats and IDs are referenced in `Assets/Catalogs/Creatures.json`.

--- a/Assets/Interface/AGENTS.md
+++ b/Assets/Interface/AGENTS.md
@@ -1,0 +1,10 @@
+# Interface Assets
+
+UI scenes and their initialization scripts.
+
+Subfolders:
+- `Login/` – login screen scripts and `view.scene` file.
+- `Main/` – main menu scripts and scene.
+- `Shared/` – small utility scripts for UI elements.
+
+`interfaceManager.script` loads the pages at runtime.

--- a/External/AGENTS.md
+++ b/External/AGENTS.md
@@ -1,0 +1,11 @@
+# External Libraries
+
+Third party dependencies.  Not written by Devacor.
+
+Notable packages:
+- `Box2D` – physics engine.
+- `ChaiScript-6.1.0` – embedded scripting language.
+- `LINQ` – boolinq C++ LINQ style queries.
+- `cereal` – serialization library.
+- `gl3w`, `glm` – OpenGL loader and math library.
+- `MVAdapters` – adapter layer for MutedVision to third party libs.

--- a/Source/AGENTS.md
+++ b/Source/AGENTS.md
@@ -1,0 +1,10 @@
+# Source Directory
+
+Top level source code.  Major components:
+
+- `MV` – the MutedVision engine.  Contains rendering, networking, utilities, physics, scripting and other engine modules.
+- `Game` – gameplay specific code such as `Game/game.h`, `building.h`, `player.h` and the network layer for game and lobby servers.
+- `Editor` – level/editor GUI code.
+- `SolutionSpecific` – entry points for each executable (client, Android client, game server, lobby server).
+
+See the AGENTS files inside those folders for more details.

--- a/Source/Editor/AGENTS.md
+++ b/Source/Editor/AGENTS.md
@@ -1,0 +1,8 @@
+# Editor Code
+
+Tools for editing scenes and assets.  Useful when investigating the in‑game editor.
+
+Important files:
+- `editor.*` – main editor application logic.
+- `componentPanels.*` / `editComponents.*` – UI panels for editing scene graph components.
+- `editorSceneGraphPanel.*` – manages the scene hierarchy view.

--- a/Source/Game/AGENTS.md
+++ b/Source/Game/AGENTS.md
@@ -1,0 +1,12 @@
+# Game Code (`Source/Game`)
+
+Gameplay specific C++ source.
+
+Notable files:
+- `game.h`/`game.cpp` – main client/game logic.
+- `managers.h` – struct bundling engine systems.
+- `player.h`, `building.h`, `creature.h` – core gameplay objects.
+- `Instance/` – `gameInstance.*` manages a running match.
+- `Interface/` – GUI helpers via `interfaceManager.*`.
+- `NetworkLayer/` – network actions plus game and lobby server implementations.
+- `Script/` – bindings for game scripts.

--- a/Source/Game/Instance/AGENTS.md
+++ b/Source/Game/Instance/AGENTS.md
@@ -1,0 +1,7 @@
+# Game Instance
+
+Components that manage a match or session.
+
+Files:
+- `gameInstance.*` – client side representation of a match.
+- `team.*` – holds team/unit data in a match.

--- a/Source/Game/Interface/AGENTS.md
+++ b/Source/Game/Interface/AGENTS.md
@@ -1,0 +1,8 @@
+# Game Interface Helpers
+
+GUI related helpers used in the client.
+
+Key files:
+- `interfaceManager.*` – manages interface pages.
+- `guiFactories.*` – helpers to create GUI controls.
+- `interfaceHooks.cxx` exposes GUI objects to scripts.

--- a/Source/Game/NetworkLayer/AGENTS.md
+++ b/Source/Game/NetworkLayer/AGENTS.md
@@ -1,0 +1,9 @@
+# Game Network Layer
+
+Contains all network messaging and server implementations.
+
+Highlights:
+- `networkAction.h` – base class for network actions.
+- `gameServer.*` – in‑match server handling.
+- `lobbyServer.*` – lobby/matchmaking server.
+- `gameServerActions.*` and `clientActions.*` – specific messages exchanged between client and servers.

--- a/Source/MV/AGENTS.md
+++ b/Source/MV/AGENTS.md
@@ -1,0 +1,15 @@
+# MutedVision Engine (`Source/MV`)
+
+Core C++ engine code used by Bindstone.
+
+Submodules:
+- `Audio` – simple sound helpers (currently placeholder).
+- `Interface` – input devices (e.g. `tapDevice.h`).
+- `Network` – networking utilities (`network.h`, `webServer.h`, etc.).
+- `Physics` – physics components (wraps Box2D).
+- `Render` – rendering system and scene graph (`Scene` subfolder holds `Node`, `Sprite`, etc.).
+- `Script` – wraps ChaiScript; see `script.cxx`/`script.h`.
+- `Serialization` – cereal based helpers.
+- `Utility` – misc helpers (thread pools, logging, async tasks, properties, etc.).
+
+The engine was written by Devacor (Michael Hamilton).

--- a/Source/MV/Network/AGENTS.md
+++ b/Source/MV/Network/AGENTS.md
@@ -1,0 +1,10 @@
+# MV Network
+
+Networking helpers including client/server wrappers and HTTP utilities.
+
+Key files:
+- `network.h` / `network.cpp` – connection and client/server abstractions.
+- `webServer.h` / `webServer.cpp` – simple web server implementation.
+- `download.*`, `url.*` – HTTP download and URL utilities.
+
+Used by both game and lobby servers as well as the client.

--- a/Source/MV/Render/Scene/AGENTS.md
+++ b/Source/MV/Render/Scene/AGENTS.md
@@ -1,0 +1,8 @@
+# MV Render Scene Graph
+
+Contains the scene graph implementation used to render sprites and UI.
+
+Key classes:
+- `Node` / `component.*` – base scene objects.
+- `Sprite`, `Text`, `Button`, `Scroller`, etc. for visual elements.
+- `sceneHooks.cxx` registers components with the MV script engine.

--- a/Source/MV/Utility/AGENTS.md
+++ b/Source/MV/Utility/AGENTS.md
@@ -1,0 +1,9 @@
+# MV Utility
+
+General helper classes used across the project.
+
+Highlights:
+- Thread pools (`asioThreadPool.*`, `threadPool.hpp`).
+- Logging (`log.h` / `log.cpp`).
+- Task system (`task.h`, `task.cpp`).
+- Properties, optional calls, timers, and string utilities.

--- a/Source/SolutionSpecific/AGENTS.md
+++ b/Source/SolutionSpecific/AGENTS.md
@@ -1,0 +1,9 @@
+# Solution Specific Entry Points
+
+Each subfolder here builds an executable:
+- `BindstoneClient` – Windows client main (`main.cpp`).
+- `BindstoneClient_Android` – Android client main.
+- `BindstoneGameServer` – dedicated game server entry point.
+- `BindstoneLobbyServer` – lobby/matchmaking server entry point.
+
+These main files depend on code in `Source/MV` and `Source/Game`.

--- a/VSProjects/AGENTS.md
+++ b/VSProjects/AGENTS.md
@@ -1,0 +1,5 @@
+# Visual Studio Projects
+
+MSVC project files used to build on Windows and Android.  Useful when locating build settings.
+
+Contains subfolders for clients, servers and the MutedVision library as well as prebuilt SDL2 projects.


### PR DESCRIPTION
## Summary
- document repository layout and key folders
- added AGENTS.md to root, assets, engine, game code, and server entrypoints

## Testing
- `git status --short`
