### PR TITLE
Migrate Text component to property registry

### DIFF
--- a/Source/MV/Render/Scene/text.cpp
+++ b/Source/MV/Render/Scene/text.cpp
@@ -4,6 +4,7 @@
 #include "cereal/archives/portable_binary.hpp"
 
 CEREAL_REGISTER_TYPE(MV::Scene::Text);
+CEREAL_CLASS_VERSION(MV::Scene::Text, 1);
 CEREAL_REGISTER_DYNAMIC_INIT(mv_scenetext);
 
 namespace MV{
@@ -173,14 +174,12 @@ namespace MV{
 			}
 		}
 
-		std::shared_ptr<Component> Text::cloneHelper(const std::shared_ptr<Component> &a_clone) {
-			Drawable::cloneHelper(a_clone);
-			auto textClone = std::static_pointer_cast<Text>(a_clone);
-			(*textClone->formattedText) = *formattedText;
-			textClone->cursor = cursor;
-			textClone->usingBoundsForLineHeight = usingBoundsForLineHeight;
-			return a_clone;
-		}
+                std::shared_ptr<Component> Text::cloneHelper(const std::shared_ptr<Component> &a_clone) {
+                        Drawable::cloneHelper(a_clone);
+                        auto textClone = std::static_pointer_cast<Text>(a_clone);
+                        textClone->cursor = cursor;
+                        return a_clone;
+                }
 
 		void Text::detachImplementation() {
 			Drawable::detachImplementation();

--- a/Source/MV/Render/Scene/text.h
+++ b/Source/MV/Render/Scene/text.h
@@ -246,16 +246,15 @@ namespace MV{
 				setCursor(cursor + a_change);
 			}
 
-TextLibrary& textLibrary;
+			TextLibrary& textLibrary;
 
-MV_PROPERTY(std::shared_ptr<FormattedText>, formattedText, {},
-[](auto &source, auto &destination) {
-if (source.get() && destination.get()) {
-*destination.get() = *source.get();
-}
-});
+			MV_PROPERTY(std::shared_ptr<FormattedText>, formattedText, {}, [](auto &source, auto &destination) {
+				if (destination.get()) {
+					*destination.get() = source.get() ? nullptr : *source.get();
+				}
+			});
 
-MV_PROPERTY(bool, usingBoundsForLineHeight, false);
+			MV_PROPERTY(bool, usingBoundsForLineHeight, false);
 
 			bool displayCursor = false;
 			size_t cursor = 0;

--- a/Source/MV/Render/Scene/text.h
+++ b/Source/MV/Render/Scene/text.h
@@ -178,23 +178,18 @@ namespace MV{
 				Text(a_owner, a_textLibrary, DEFAULT_ID) {
 			}
 
-			template <class Archive>
-			void save(Archive & archive, std::uint32_t const /*version*/) const {
-				archive(
-					CEREAL_NVP(formattedText),
-					CEREAL_NVP(usingBoundsForLineHeight),
-					cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
-				);
-			}
+                        template <class Archive>
+                        void save(Archive & archive, std::uint32_t const /*version*/) const {
+                                archive(cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this)));
+                        }
 
-			template <class Archive>
-			void load(Archive & archive, std::uint32_t const /*version*/) {
-				archive(
-					CEREAL_NVP(formattedText),
-					CEREAL_NVP(usingBoundsForLineHeight),
-					cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
-				);
-			}
+                        template <class Archive>
+                        void load(Archive & archive, std::uint32_t const version) {
+                                if (version == 0) {
+                                        properties.load(archive, { "formattedText", "usingBoundsForLineHeight" });
+                                }
+                                archive(cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this)));
+                        }
 
 			template <class Archive>
 			static void load_and_construct(Archive & archive, cereal::construct<Text> &construct, std::uint32_t const version) {
@@ -251,11 +246,16 @@ namespace MV{
 				setCursor(cursor + a_change);
 			}
 
-			TextLibrary& textLibrary;
+TextLibrary& textLibrary;
 
-			std::shared_ptr<FormattedText> formattedText;
+MV_PROPERTY(std::shared_ptr<FormattedText>, formattedText, {},
+[](auto &source, auto &destination) {
+if (source.get() && destination.get()) {
+*destination.get() = *source.get();
+}
+});
 
-			bool usingBoundsForLineHeight = false;
+MV_PROPERTY(bool, usingBoundsForLineHeight, false);
 
 			bool displayCursor = false;
 			size_t cursor = 0;


### PR DESCRIPTION
## Summary
- support property-based serialization in `Text`
- version `Text` cereal archive
- add cloning logic through property helpers

## Testing
- `git status --short`
