### PR TITLE
Fix Sprite serialization properties

### DIFF
--- a/Source/MV/Render/Scene/sprite.h
+++ b/Source/MV/Render/Scene/sprite.h
@@ -47,25 +47,22 @@ namespace MV {
 				appendQuadVertexIndices(*vertexIndices, 0);
 			}
 
-			template <class Archive>
-			void save(Archive & archive, std::uint32_t const version) const {
-				if (version > 0) {
-					archive(cereal::make_nvp("subdivisions", ourSubdivisions));
-				}
-				archive(
-					cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
-				);
-			}
+                       template <class Archive>
+                       void save(Archive & archive, std::uint32_t const /*version*/) const {
+                               archive(
+                                       cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
+                               );
+                       }
 
-			template <class Archive>
-			void load(Archive & archive, std::uint32_t const version) {
-				if (version > 0) {
-					archive(cereal::make_nvp("subdivisions", ourSubdivisions));
-				}
-				archive(
-					cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
-				);
-			}
+                       template <class Archive>
+                       void load(Archive & archive, std::uint32_t const version) {
+                               if (version == 0) {
+                                       properties.load(archive, { "subdivisions" });
+                               }
+                               archive(
+                                       cereal::make_nvp("Drawable", cereal::base_class<Drawable>(this))
+                               );
+                       }
 
 			template <class Archive>
 			static void load_and_construct(Archive & archive, cereal::construct<Sprite> &construct, std::uint32_t const version) {
@@ -100,7 +97,7 @@ namespace MV {
 
 			void updateTextureCoordinates(size_t a_textureId) override;
 
-			uint16_t ourSubdivisions = 0;
+                       Property<uint16_t> ourSubdivisions{properties, "subdivisions", 0};
 		};
 
 		template<typename PointAssign>


### PR DESCRIPTION
## Summary
- convert `Sprite::ourSubdivisions` to a `Property`
- serialize only the `Drawable` base class
- load old archives using `properties.load`
- keep class version at 1 for legacy compatibility

## Testing
- `true`