### PR TITLE
Refine clickable properties

### DIFF
--- a/Source/MV/Render/Scene/clickable.cpp
+++ b/Source/MV/Render/Scene/clickable.cpp
@@ -3,7 +3,10 @@
 #include "stencil.h"
 
 #include "cereal/archives/json.hpp"
+
 #include "cereal/archives/portable_binary.hpp"
+
+CEREAL_CLASS_VERSION(MV::Scene::Clickable, 1);
 
 CEREAL_REGISTER_TYPE(MV::Scene::Clickable);
 CEREAL_REGISTER_DYNAMIC_INIT(mv_sceneclickable);
@@ -223,13 +226,10 @@ namespace MV {
 			acceptUpClick(true);
 		}
 
-		std::shared_ptr<Component> Clickable::cloneHelper(const std::shared_ptr<Component> &a_clone) {
-			Sprite::cloneHelper(a_clone);
-			auto clickableClone = std::static_pointer_cast<Clickable>(a_clone);
-			clickableClone->eatTouches = eatTouches;
-			clickableClone->hitDetectionType = hitDetectionType;
-			return a_clone;
-		}
+                std::shared_ptr<Component> Clickable::cloneHelper(const std::shared_ptr<Component> &a_clone) {
+                        Sprite::cloneHelper(a_clone);
+                        return a_clone;
+                }
 
 	}
 }

--- a/Source/MV/Render/Scene/clickable.h
+++ b/Source/MV/Render/Scene/clickable.h
@@ -141,41 +141,23 @@ namespace MV {
 
 			virtual void acceptUpClick(bool a_ignoreBounds = false);
 
-			template <class Archive>
-			void save(Archive & archive, std::uint32_t const /*version*/) const {
-				archive(
-					cereal::make_nvp("onPress", onPressSignal),
-					cereal::make_nvp("onRelease", onReleaseSignal),
-					cereal::make_nvp("onDrag", onDragSignal),
-					cereal::make_nvp("onAccept", onAcceptSignal),
-					cereal::make_nvp("onCancel", onCancelSignal),
-					cereal::make_nvp("onDrop", onDropSignal),
-					cereal::make_nvp("hitDetectionType", hitDetectionType),
-					cereal::make_nvp("eatTouches", eatTouches),
-					cereal::make_nvp("globalClickPriority", globalClickPriority),
-					cereal::make_nvp("appendClickPriority", appendClickPriority),
-					cereal::make_nvp("overrideClickPriority", overrideClickPriority),
-					cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this))
-				);
-			}
+                       template <class Archive>
+                       void save(Archive & archive, std::uint32_t const /*version*/) const {
+                               archive(cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this)));
+                       }
 
-			template <class Archive>
-			void load(Archive & archive, std::uint32_t const /*version*/) {
-				archive(
-					cereal::make_nvp("onPress", onPressSignal),
-					cereal::make_nvp("onRelease", onReleaseSignal),
-					cereal::make_nvp("onDrag", onDragSignal),
-					cereal::make_nvp("onAccept", onAcceptSignal),
-					cereal::make_nvp("onCancel", onCancelSignal),
-					cereal::make_nvp("onDrop", onDropSignal),
-					cereal::make_nvp("hitDetectionType", hitDetectionType),
-					cereal::make_nvp("eatTouches", eatTouches),
-					cereal::make_nvp("globalClickPriority", globalClickPriority),
-					cereal::make_nvp("appendClickPriority", appendClickPriority),
-					cereal::make_nvp("overrideClickPriority", overrideClickPriority),
-					cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this))
-				);
-			}
+                        template <class Archive>
+                        void load(Archive & archive, std::uint32_t const version) {
+                               if(version == 0) {
+                                       properties.load(archive, {
+                                               "onPress", "onRelease", "onDrag", "onAccept", "onCancel", "onDrop",
+                                               "hitDetectionType", "eatTouches", "globalClickPriority", "appendClickPriority", "overrideClickPriority"
+                                       });
+                               } else {
+                                       properties.load(archive);
+                               }
+                               archive(cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this)));
+                       }
 
 			template <class Archive>
 			static void load_and_construct(Archive & archive, cereal::construct<Clickable> &construct, std::uint32_t const version) {
@@ -199,8 +181,8 @@ namespace MV {
 				onMouseMoveHandle.reset();
 			}
 
-			int64_t globalClickPriority = 100;
-			int64_t appendClickPriority = 0;
+                       MV_PROPERTY(int64_t, globalClickPriority, 100, [](auto &, auto &){ });
+                       MV_PROPERTY(int64_t, appendClickPriority, 0, [](auto &, auto &){ });
 		private:
 			TapDevice::SignalType onLeftMouseDownHandle;
 			TapDevice::SignalType onLeftMouseUpHandle;
@@ -221,9 +203,9 @@ namespace MV {
 			std::string onAcceptScript;
 			std::string onCancelScript;
 
-			std::vector<int64_t> overrideClickPriority;
-			bool eatTouches = true;
-			BoundsType hitDetectionType = BoundsType::LOCAL;
+                        MV_PROPERTY(std::vector<int64_t>, overrideClickPriority, {}, [](auto &, auto &){ });
+                        MV_PROPERTY(bool, eatTouches, true);
+                        MV_PROPERTY(BoundsType, hitDetectionType, BoundsType::LOCAL);
 		};
 
 	}

--- a/Source/MV/Render/Scene/clickable.h
+++ b/Source/MV/Render/Scene/clickable.h
@@ -143,18 +143,27 @@ namespace MV {
 
                        template <class Archive>
                        void save(Archive & archive, std::uint32_t const /*version*/) const {
+				archive(cereal::make_nvp("onPress", onPressSignal),
+					cereal::make_nvp("onRelease", onReleaseSignal),
+					cereal::make_nvp("onDrag", onDragSignal),
+					cereal::make_nvp("onAccept", onAcceptSignal),
+					cereal::make_nvp("onCancel", onCancelSignal),
+					cereal::make_nvp("onDrop", onDropSignal));
                                archive(cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this)));
                        }
 
                         template <class Archive>
                         void load(Archive & archive, std::uint32_t const version) {
+				archive(cereal::make_nvp("onPress", onPressSignal),
+					cereal::make_nvp("onRelease", onReleaseSignal),
+					cereal::make_nvp("onDrag", onDragSignal),
+					cereal::make_nvp("onAccept", onAcceptSignal),
+					cereal::make_nvp("onCancel", onCancelSignal),
+					cereal::make_nvp("onDrop", onDropSignal));
                                if(version == 0) {
                                        properties.load(archive, {
-                                               "onPress", "onRelease", "onDrag", "onAccept", "onCancel", "onDrop",
                                                "hitDetectionType", "eatTouches", "globalClickPriority", "appendClickPriority", "overrideClickPriority"
                                        });
-                               } else {
-                                       properties.load(archive);
                                }
                                archive(cereal::make_nvp("Sprite", cereal::base_class<Sprite>(this)));
                        }


### PR DESCRIPTION
## Summary
- serialize `Clickable` using property registry
- ignore legacy fields when loading newer versions
- prevent priority properties from cloning

## Testing
- `g++ -std=c++17 -I./Source -I./External/cereal/include minimal_test/main.cpp minimal_test/cereal_cat.cpp -o minimal_test/test_program` *(fails: MV/Utility/properties.h missing)*